### PR TITLE
Do not ignore the build folder

### DIFF
--- a/deps/node_modules/3scale/node_modules/libxmljs/.npmignore
+++ b/deps/node_modules/3scale/node_modules/libxmljs/.npmignore
@@ -1,5 +1,4 @@
 .lock-wscript
 *.swp
-build/
 node_modules/
 npm-debug.log


### PR DESCRIPTION
The `build` subfolder must be included because it contains the precompiled native dependencies of libxmljs.

Otherwise it ignores it when doing `npm install` of the `3scale-cli`, which depends on this library.
